### PR TITLE
support laravel 5.0-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "manavo/laravel-bootstrap-forms",
-    "description": "Recude the boilerplate code required to get forms in Laravel to have Bootstrap styling",
+    "description": "Reduce the boilerplate code required to get forms in Laravel to have 
+Bootstrap styling",
     "license": "MIT",
     "authors": [
         {

--- a/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
+++ b/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
@@ -18,7 +18,11 @@ class BootstrapFormsServiceProvider extends IlluminateHtmlServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('manavo/bootstrap-forms');
+		$laravel = app();
+		if (version_compare($laravel::VERSION, '4.2', '<='))
+		{
+			$this->package('manavo/bootstrap-forms');
+		}
 	}
 
 	/**


### PR DESCRIPTION
the package() call in the boot() method no longer seems to work in laravel 5.0-dev. I am not 100% this is the correct approach to the problem, but this works-for-me™.

Also, version_compare() checks for 4.2 or lower, since it considers "5.0-dev" to be below 5.0.

/m