### PR TITLE
Fix a couple minor gotchas

### DIFF
--- a/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
+++ b/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
@@ -19,7 +19,9 @@ class BootstrapFormsServiceProvider extends IlluminateHtmlServiceProvider
      */
     public function boot()
     {
-        $this->package('manavo/bootstrap-forms');
+        if (version_compare($app::VERSION, '5.0') < 0) {
+            $this->package('manavo/bootstrap-forms');
+        }
     }
 
     /**

--- a/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
+++ b/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
@@ -19,6 +19,7 @@ class BootstrapFormsServiceProvider extends IlluminateHtmlServiceProvider
      */
     public function boot()
     {
+        $app = $this->app;
         if (version_compare($app::VERSION, '5.0') < 0) {
             $this->package('manavo/bootstrap-forms');
         }

--- a/src/Manavo/BootstrapForms/FormBuilder.php
+++ b/src/Manavo/BootstrapForms/FormBuilder.php
@@ -105,7 +105,7 @@ class FormBuilder extends IlluminateFormBuilder
     public function input($type, $name, $value = null, $options = [])
     {
         // Don't add form-control for some input types (like submit, checkbox, radio)
-        if (!in_array($type, ['submit', 'checkbox', 'radio', 'reset'])) {
+        if (!in_array($type, ['submit', 'checkbox', 'radio', 'reset', 'file'])) {
             $options = $this->appendClassToOptions('form-control', $options);
         }
 

--- a/src/Manavo/BootstrapForms/FormBuilder.php
+++ b/src/Manavo/BootstrapForms/FormBuilder.php
@@ -194,7 +194,6 @@ class FormBuilder extends IlluminateFormBuilder
      *
      * @param  string $name
      * @param  mixed  $value
-     * @param  mixed  $label
      * @param  bool   $checked
      * @param  array  $options
      *
@@ -203,13 +202,14 @@ class FormBuilder extends IlluminateFormBuilder
     public function checkbox(
         $name,
         $value = 1,
-        $label = null,
         $checked = null,
         $options = []
     ) {
         $checkable = parent::checkbox($name, $value, $checked, $options);
 
-        return $this->wrapCheckable($label, 'checkbox', $checkable);
+        return @$options['label'] ?
+            $this->wrapCheckable($options['label'], 'checkbox', $checkable) :
+            $checkable;
     }
 
     /**


### PR DESCRIPTION

1. File inputs look weird when wrapped with a `.form-control`.
2. `checkbox()` signature changed in this helper in a way that wasn't compatible with `Illuminate\Html\FormBuilder`. Now, instead of `$label` being a parameter it's passed in through `$options`.