### PR TITLE
Merge Incompatible Laravel 5.2 Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Using [@stidges](https://github.com/stidges)' code for bootstrap forms to create a composer package. You can find the original article here: http://blog.stidges.com/post/easy-bootstrap-forms-in-laravel
 
+Note this is not compatible with Laravel < 5.2.
+
 ## Install
 
 ```
@@ -10,19 +12,17 @@ composer require manavo/laravel-bootstrap-forms ~0.1
 
 ## Configure
 
-Make sure you comment out the existing HtmlServiceProvider (Illuminate\Html\HtmlServiceProvider):
+Make sure you comment out the existing HtmlServiceProvider (Collectve\Html\HtmlServiceProvider):
 
 ```php
 <?php
-// File (Laravel 4): app/config/app.php
-// OR
 // File (Laravel 5): config/app.php
 
 return array(
     // ...
     'providers' => array(
         // ...
-        // 'Illuminate\Html\HtmlServiceProvider',
+        // 'Collective\Html\HtmlServiceProvider',
         'Manavo\BootstrapForms\BootstrapFormsServiceProvider',
         // ...
     ),
@@ -35,15 +35,15 @@ No change is necessary for the Form Facade.
 ## Example
 
 ```
-{{ Form::open([ 'route' => 'posts.store' ]) }}
+{!! Form::open([ 'route' => 'posts.store' ]) !!}
 
-    {{ Form::openGroup('title', 'Title') }}
-        {{ Form::text('title') }}
-    {{ Form::closeGroup() }}
+    {!! Form::openGroup('title', 'Title') !!}
+        {!! Form::text('title') !!}
+    {!! Form::closeGroup() !!}
 
-    {{ Form::openGroup('status', 'Status') }}
-        {{ Form::select('status', $statusOptions) }}
-    {{ Form::closeGroup() }}
+    {!! Form::openGroup('status', 'Status') !!}
+        {!! Form::select('status', $statusOptions) !!}
+    {!! Form::closeGroup() !!}
 
-{{ Form::close() }}
+{!! Form::close() !!}
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "Philip Manavopoulos",
             "email": "manavo@gmail.com"
+        },
+        {
+            "name": "David Lloyd",
+            "email": "lloy0076@adam.com.au"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.4.0",
+        "laravelcollective/html": "5.2.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
+++ b/src/Manavo/BootstrapForms/BootstrapFormsServiceProvider.php
@@ -1,8 +1,8 @@
 <?php namespace Manavo\BootstrapForms;
 
-use Illuminate\Html\HtmlServiceProvider as IlluminateHtmlServiceProvider;
+use Collective\Html\HtmlServiceProvider as CollectiveHtmlServiceProvider;
 
-class BootstrapFormsServiceProvider extends IlluminateHtmlServiceProvider
+class BootstrapFormsServiceProvider extends CollectiveHtmlServiceProvider
 {
 
     /**
@@ -32,9 +32,9 @@ class BootstrapFormsServiceProvider extends IlluminateHtmlServiceProvider
      */
     public function registerFormBuilder()
     {
-        $this->app->bindShared('form', function ($app) {
+        $this->app->singleton('form', function ($app) {
             $form = new FormBuilder($app['html'], $app['url'],
-                $app['session.store']->getToken());
+                $app['view'], $app['session.store']->getToken());
 
             return $form->setSessionStore($app['session.store']);
         });

--- a/src/Manavo/BootstrapForms/FormBuilder.php
+++ b/src/Manavo/BootstrapForms/FormBuilder.php
@@ -2,9 +2,9 @@
 
 namespace Manavo\BootstrapForms;
 
-use Illuminate\Html\FormBuilder as IlluminateFormBuilder;
+use Collective\Html\FormBuilder as CollectiveFormBuilder;
 
-class FormBuilder extends IlluminateFormBuilder
+class FormBuilder extends CollectiveFormBuilder
 {
 
     /**


### PR DESCRIPTION
NOTE: This probably should be in a branch but I don't know how to make pull requests that make branches.

This:
1. Requires Laravel 5.2 (possibly it will work on lower);
2. Requires the HTML Builders from "laravelcollective";
3. Fixes the example so that the "<div>" for the open group etc. don't actually get HTML escaped;
4. Renames Illuminate to Collective where necessary.
